### PR TITLE
Latest @apollo/subgraph library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+neo4j-data/

--- a/README.md
+++ b/README.md
@@ -49,11 +49,28 @@ mutation CreateActors {
     input: [
       {
         name: "Richard Dreyfuss"
-        connect: { where: { node: { id: "<ID FROM JAWS>" } } }
+        movies: {
+          connect: {
+            where: {
+              node: {
+                id: "<ID FROM JAWS>"
+              }
+            }
+          }
+        }
+
       }
       {
         name: "Janet Leigh"
-        connect: { where: { node: { id: "<ID FROM PSYCHO>" } } }
+        movies: {
+          connect: {
+            where: {
+              node: {
+                id: "<ID FROM PSYCHO>"
+              }
+            }
+          }
+        }
       }
     ]
   ) {

--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@ import neo4j from "neo4j-driver";
 import ogmPkg from "@neo4j/graphql-ogm";
 import { ApolloServer, gql } from "apollo-server";
 import { config } from "dotenv";
-import { createEntityDataloaderFactory } from "./entity-dataloaders.js";
-import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { extractSelectionSetMap } from "./entity-dataloaders.js";
+import { getResolversFromSchema, printSchemaWithDirectives } from "@graphql-tools/utils";
+import { buildSubgraphSchema } from "@apollo/subgraph";
 
 const { OGM } = ogmPkg;
 
@@ -16,12 +17,6 @@ const typeDefs = gql`
   scalar _FieldSet
   scalar _Any
   directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
-
-  union _Entity = Actor | Movie
-
-  type Query {
-    _entities(representations: [_Any!]!): [_Entity]!
-  }
 
   type Movie @key(fields: "id") {
     id: ID! @id
@@ -43,64 +38,72 @@ const driver = neo4j.driver(
 
 const ogm = new OGM({ typeDefs, driver });
 
-/** @type {import("./entity-dataloaders.js").EntityConfiguration<any, any>[]} */
-const entityConfiguration = [
-  {
-    name: "Movie",
-    model: ogm.model("Movie"),
-    refToKey: (ref) => ref.id,
-    whereClause: (keys) => ({ id_IN: keys }),
-  },
-  {
-    name: "Actor",
-    model: ogm.model("Actor"),
-    refToKey: (ref) => ref.id,
-    whereClause: (keys) => ({ id_IN: keys }),
-  },
-];
-
-const entityDataloaderFactory =
-  createEntityDataloaderFactory(entityConfiguration);
-
 const neoSchema = new Neo4jGraphQL({
   typeDefs,
-  driver,
-  resolvers: {
-    Query: {
-      _entities(_source, { representations }, _context, info) {
-        const dataloaders = entityDataloaderFactory(
-          info.fieldNodes[0].selectionSet
-        );
-
-        // Using dataloader.load ensures that the entities are returned in the
-        // same order as the representations argument. This is critical for
-        // ensuring that entities are correctly joined across subgraphs.
-        return representations.map((reference) => {
-          const { __typename } = reference;
-          return dataloaders.get(__typename).load(reference);
-        });
-      },
-    },
-    _Entity: {
-      /**
-       * @param {{ __typename: string; }} ref
-       */
-      __resolveType(ref) {
-        return ref.__typename;
-      },
-    },
-  },
+  driver
 });
 
 await ogm.init();
 const schema = await neoSchema.getSchema();
-
+const printedSchema = printSchemaWithDirectives(schema);
 // print the full schema to stdout if asked
 if (process.argv[2] === "print") {
-  console.log(printSchemaWithDirectives(schema));
+  console.log(printedSchema);
 } else {
   // otherwise run a server
-  const server = new ApolloServer({ schema });
+  const resolvers = getResolversFromSchema(schema);
+  const server = new ApolloServer({
+    // @ts-ignore - the getResolversFromSchema type doesn't match the resolvers property type.
+    schema: buildSubgraphSchema({
+      typeDefs: gql(printedSchema),
+      resolvers: {
+        // Include all resolvers that are part of the schema...
+        ...resolvers,
+        Movie: {
+          // Include all resolvers that are part of the movie entity...
+          ...resolvers.Movie,
+          // Define the reference resolver: https://www.apollographql.com/docs/federation/entities/#2-define-a-reference-resolver
+          /**
+           * Resolves Movie entity references.
+           * @param {{ id: string }} movie
+           * @param {*} context
+           * @param {import("graphql").GraphQLResolveInfo} info
+           */
+          __resolveReference: async ({id}, context, info) => {
+            // TODO: Data loader
+            const selectionSetMap = extractSelectionSetMap(info.fieldNodes[0].selectionSet);
+            const selectStatement = selectionSetMap.get("Movie");
+            const result = await ogm.model("Movie").find({
+              where: { id },
+              selectionSet: selectStatement
+            });
+
+            return result.length ? result[0] : null;
+          }
+        },
+        Actor: {
+          ...resolvers.Actor,
+          /**
+           * Resolves Actor entity references.
+           * @param {{id: string}} param0
+           * @param {*} context
+           * @param {import("graphql").GraphQLResolveInfo} info
+           */
+          __resolveReference: async ({id}, context, info) => {
+            // TODO: Data loader
+            const selectionSetMap = extractSelectionSetMap(info.fieldNodes[0].selectionSet);
+            const selectStatement = selectionSetMap.get("Actor");
+            const result = await ogm.model("Actor").find({
+              where: { id },
+              selectionSet: selectStatement
+            });
+
+            return result.length ? result[0] : null;
+          }
+        }
+      }
+    })
+  });
   const { url } = await server.listen(4000);
   console.log(`🚀 Server ready at ${url}`);
 }

--- a/index.js
+++ b/index.js
@@ -70,15 +70,18 @@ if (process.argv[2] === "print") {
            * @param {import("graphql").GraphQLResolveInfo} info
            */
           __resolveReference: async ({id}, context, info) => {
-            // TODO: Data loader
+            console.log("Resolving Movie with Id ", id);
+
             const selectionSetMap = extractSelectionSetMap(info.fieldNodes[0].selectionSet);
             const selectStatement = selectionSetMap.get("Movie");
-            const result = await ogm.model("Movie").find({
+            const movies = await ogm.model("Movie").find({
               where: { id },
               selectionSet: selectStatement
             });
 
-            return result.length ? result[0] : null;
+            console.log("Located movies ", movies);
+
+            return movies.length ? movies[0] : null;
           }
         },
         Actor: {
@@ -90,15 +93,18 @@ if (process.argv[2] === "print") {
            * @param {import("graphql").GraphQLResolveInfo} info
            */
           __resolveReference: async ({id}, context, info) => {
-            // TODO: Data loader
+            console.log("Resolving Actor with Id ", id);
+
             const selectionSetMap = extractSelectionSetMap(info.fieldNodes[0].selectionSet);
             const selectStatement = selectionSetMap.get("Actor");
-            const result = await ogm.model("Actor").find({
+            const actors = await ogm.model("Actor").find({
               where: { id },
               selectionSet: selectStatement
             });
 
-            return result.length ? result[0] : null;
+            console.log("Located actors ", actors)
+
+            return actors.length ? actors[0] : null;
           }
         }
       }

--- a/neo4j.sh
+++ b/neo4j.sh
@@ -1,0 +1,4 @@
+CURRENT_DIR=$(pwd)
+set -x;
+docker run -d --name neo4j -p 7474:7474 -p 7473:7473 -p 7687:7687 \
+    -v "$CURRENT_DIR/neo4j-data:/data" -e NEO4J_AUTH=neo4j/test neo4j:latest

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "node --experimental-vm-modules $(yarn bin)/jest"
   },
   "dependencies": {
-    "@apollo/subgraph": "^0.4.0",
+    "@apollo/subgraph": "^2.0.1",
     "@graphql-tools/utils": "^8.6.5",
     "@neo4j/graphql": "^3.0.3",
     "@neo4j/graphql-ogm": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,22 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
+"@apollo/core-schema@~0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@apollo/core-schema/-/core-schema-0.3.0.tgz#c6c1a6821fb326501d73eb85d920bbf57906cc77"
+  integrity sha512-v+Ys6+W1pDQu+XwP++tI5y4oZdzKrEuVXwsEenOmg2FO/3/G08C+qMhQ9YQ9Ug34rvQGQtgbIDssHEVk4YZS7g==
+  dependencies:
+    "@protoplasm/recall" "^0.2"
+
+"@apollo/federation-internals@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/federation-internals/-/federation-internals-2.0.1.tgz#582bbc732015ec63117da958e79ded7495fbbf79"
+  integrity sha512-as2lL0tChwQx3PgBKQ8hELal2paBFsbucXSba+Gi84ZP1wGtYtl5kJmE7DVImsC+/CAVjEFWM7aWQGJg6Im8Ow==
+  dependencies:
+    "@apollo/core-schema" "~0.3.0"
+    chalk "^4.1.0"
+    js-levenshtein "^1.1.6"
+
 "@apollo/protobufjs@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.2.tgz#4bd92cd7701ccaef6d517cdb75af2755f049f87c"
@@ -28,10 +44,12 @@
     "@types/node" "^10.1.0"
     long "^4.0.0"
 
-"@apollo/subgraph@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@apollo/subgraph/-/subgraph-0.4.0.tgz#4c6fc2bcc03b1715e7bcb7071f79512f3c5cee1e"
-  integrity sha512-Fg9XGaXpFP+X2J5HswIin/0ksmZShdukBtmtbMgvxJs7wfStlr+7m8gice4YSXYm/nu4td+UxUAfaqUjLYiFbQ==
+"@apollo/subgraph@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/subgraph/-/subgraph-2.0.1.tgz#ae638802c9841fc3189b9e8545a93bfab0378c90"
+  integrity sha512-GHfJ+W7A2yiES+7nKlPFcjDuXFbj/hgGADVcNo+3HUSHOR8l+7gUhn/7pED0bhUPO5Dr2yEgz7aA39MiQ6PHTQ==
+  dependencies:
+    "@apollo/federation-internals" "^2.0.1"
 
 "@apollographql/apollo-tools@^0.5.3":
   version "0.5.3"
@@ -990,6 +1008,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
+"@protoplasm/recall@^0.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@protoplasm/recall/-/recall-0.2.2.tgz#4d8b259efba89938220088d444011b961ae3775a"
+  integrity sha512-grQIYNd3UsFjHXL1g5Qw5MdUNAddEcD1KfqiO6WeMOQHgIgECXo7r4jfcXGIh37q17HoGQgq/G4guMGkzQ+UOA==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -3490,6 +3513,11 @@ jest@^27.5.1:
     "@jest/core" "^27.5.1"
     import-local "^3.0.2"
     jest-cli "^27.5.1"
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description
This example project is a bit outdated in terms of the `@apollo/subgraph` version is was using. As a result, many of the implementation details described in the Apollo Federation documentation, like defining `__resolveReference` resolvers do not work.

This PR updates that dependency and the corresponding code that allows the `@neo4j/graphl` library to be used as a true Apollo Federation subgraph with as few barriers and additional complexity as possible by leveraging Apollo Federation's latest advancements and capabilities.

## Changes
* Updated `@apollo/subgraph` from `^0.4.0` to `^2.0.1`
* Updated the README's snippets for seeding example data
* Included a sell script to run a neo4j database in a container for easier local development
* Updated the Apollo Server instantiation to build up [entity reference resolvers](https://www.apollographql.com/docs/federation/entities/#2-define-a-reference-resolver) and combine them with the native Neo4J resolvers.

## Remaining work
* The README file's introductory paragraphs need a little rephrasing to better align with this implementation, since it now relies on `@apollo/subgraph` for the `_entities()` query and `_Entity` type definitions.